### PR TITLE
Properly export API, make more flexible

### DIFF
--- a/GDPR.swift
+++ b/GDPR.swift
@@ -1,9 +1,14 @@
-class GDPR {
-    open func sanitizeUserData(_ userData:[Any]) -> [Any] {
+public enum GDPR {
+  
+    static func sanitizeUserData<T>(_ userData: [ T ]) -> [ T ] {
         return []
     }
     
-    open func sanitizeUserData(_ userData:[AnyHashable:Any]) -> [AnyHashable:Any] {
+    static func sanitizeUserData<K, V>(_ userData: [ K : V ]) -> [ K : V ] {
         return [:]
+    }
+
+    static func sanitizeUserData<T>(_ userData: T) -> T? {
+        return nil
     }
 }


### PR DESCRIPTION
Use generics to expand the API.

Also the old class wasn't public and the methods
haven't been static (i.e. the API didn't actually
work as shown).
Fixed that by using an enum.